### PR TITLE
use desk ancestry for package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package specification defines package metadata (name, etc.) as well as all t
 {
   "name": "package",
   "description": "A package manager for urbit",
-  "hash": "0vg.dk490.mq164.aia0o.06up6.6miom.uuav2.2fg44.eaqj1.cin5n.pidt2",
+  "hash": "0vg.frcc0.nh5a0.trbqa.1rqe5.3c1tq.kg69n.8fo2f.jkcuo.ge1gc.tdd59",
   "homepage": "https://github.com/asssaf/urbit-package",
   "items": [
     {
@@ -57,12 +57,12 @@ The URL can point to any web server. It can be a github page of a published pack
 #### Install Package
 Install a package into a desk with %xyz prefix (will create %xyz-package desk)
 ```
-> :package [%install %xyz (need (epur 'https://github.com/asssaf/urbit-package/package.json'))]
+> :package [%install %xyz (need (epur 'https://raw.githubusercontent.com/asssaf/urbit-package/master/package.json'))]
 ```
 
 For copying local dev app:
 ```
-:package [%install %dev (need (epur 'http://localhost.localdomain:8080/pages/packages/mypackage.json'))
+:package [%install %dev (need (epur 'http://localhost.localdomain:8080/pages/packages/mypackage.json'))]
 ```
 
 Note: When using `++  epur` with `http://localhost` it will set the secure flag and this will cause an http parse error. You can use something like `http://localhost.localdomain` as a workaround (assuming it is defined in `/etc/hosts`).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The package specification defines package metadata (name, etc.) as well as all t
 {
   "name": "package",
   "description": "A package manager for urbit",
+  "hash": "0vg.dk490.mq164.aia0o.06up6.6miom.uuav2.2fg44.eaqj1.cin5n.pidt2",
   "homepage": "https://github.com/asssaf/urbit-package",
   "items": [
     {
@@ -54,46 +55,24 @@ The URL can point to any web server. It can be a github page of a published pack
 
 ### Dojo
 #### Install Package
+Install a package into a desk with %xyz prefix (will create %xyz-package desk)
 ```
-> |merge %packagedesk our %base
-> :package [%install %packagedesk (need (epur 'https://github.com/asssaf/urbit-package/package.json'))]
+> :package [%install %xyz (need (epur 'https://github.com/asssaf/urbit-package/package.json'))]
 ```
 
 For copying local dev app:
 ```
-:package [%install %mydevdesk (need (epur 'http://localhost.localdomain:8080/pages/packages/mypackage.json'))
+:package [%install %dev (need (epur 'http://localhost.localdomain:8080/pages/packages/mypackage.json'))
 ```
 
 Note: When using `++  epur` with `http://localhost` it will set the secure flag and this will cause an http parse error. You can use something like `http://localhost.localdomain` as a workaround (assuming it is defined in `/etc/hosts`).
 
-#### List Installed Packages
-```
-> :package [%installed %packagedesk]
-{%package}
-```
-
-#### List Package Contents
-```
-> :package [%contents %packagedesk %package]
-```
-
-#### Find Package Owning a File
-```
-> :package [%belongs %packagedesk /app/package/hoon]
-[~ %package]
-```
-
-#### Uninstall Package
-```
-> :package [%uninstall %packagedesk %package]
-```
-
 #### Resume
-Resume in case installation stopped (e.g. due to conflict):
+Resume in case installation stopped:
 ```
 > : package [%resume %packagedesk]
 ```
 
 ## Future
 * Web interface for installing packages without the dojo
-* Poll URLs for changes and autosync (copy changed files as soon as they're save in your IDE)
+* Poll URLs for changes and autosync (copy changed files as soon as they're saved in your IDE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "package",
   "description": "A package manager for urbit",
+  "hash": "0vg.frcc0.nh5a0.trbqa.1rqe5.3c1tq.kg69n.8fo2f.jkcuo.ge1gc.tdd59",
   "homepage": "https://github.com/asssaf/urbit-package",
   "items": [
     {

--- a/src/mar/package/package.hoon
+++ b/src/mar/package/package.hoon
@@ -14,8 +14,11 @@
     |%
     ++  purl-parser
       =+  jo
-      (cu |=(a/@t (need (epur a))) so)
+      (ci |=(a/@t (epur a)) so)
     ::
+    ++  hash-parser
+      =+  jo
+      (ci |=(a/@t (slaw %uv a)) so)
     ++  rels-parser
       =+  jo
       (ar (cu |=(a/@t (stab a)) so))
@@ -44,7 +47,7 @@
     ::
     ++  package-parser
       =+  jo
-      (ot name+so items+(ar item-parser) ~)
+      (ot name+so hash+hash-parser items+(ar item-parser) ~)
     --
   --
 --

--- a/src/sur/package.hoon
+++ b/src/sur/package.hoon
@@ -5,6 +5,7 @@
 ++  pname  @tas
 ++  package
   $:  name/pname
+      hash/@uvI
       items/(list item)
   ==
 ++  item
@@ -14,23 +15,13 @@
 ++  package-item  purl
 ++  fileset-item  {base/purl rels/(list path)}
 ++  action
-  $%  {$installed d/desk}
-      {$install d/desk p/package-item:package}
-      {$uninstall d/desk p/pname}
-      {$verify d/desk p/pname}
-      {$contents d/desk p/pname}
-      {$belongs d/desk pax/path}
+  $%  {$install d/desk p/package-item:package}
       {$resume d/desk}
       {$help @tas}
   ==
 ++  action-help
   %-  my
-  :~  [%installed arg=["desk"] desc="Show list of installed packages in a desk"]
-      [%install arg=["desk purl"] desc="Fetch and install a pacakge in  a desk"]
-      [%uninstall arg=["desk name"] desc="Uninstall package in a desk"]
-      [%verify arg=["desk name"] desc="Verify files of package in a desk"]
-      [%contents arg=["desk name"] desc="Show files of package in a desk"]
-      [%belongs arg=["desk path"] desc="Show package owning path in a desk"]
+  :~  [%install arg=["desk purl"] desc="Fetch and install a pacakge in  a desk"]
       [%resume arg=["desk"] desc="Resume installation in a desk"]
       [%help arg=["action"] desc="Show help for action"]
   ==


### PR DESCRIPTION
Thanks to sorreg-namtyv's feedback in [fora](https://urbit.org/fora/posts/~2017.9.7..23.20.06..dc47~) I've changed the package app to use desk ancestry for dependency management, simplifying the app in terms of housekeeping.

Each time a package or a dependency is installed the content hash of the desk is fetched and a label is created in the desk. This label is used to verify whether a specific version of a package is installed (and when merging specific dependency versions based on their hash).